### PR TITLE
472 ct pass

### DIFF
--- a/common/src/main/java/org/apache/nemo/common/ir/edge/executionproperty/CommunicationPatternProperty.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/edge/executionproperty/CommunicationPatternProperty.java
@@ -52,6 +52,7 @@ public final class CommunicationPatternProperty
   public enum Value {
     ONE_TO_ONE,
     BROADCAST,
-    SHUFFLE
+    SHUFFLE,
+    PARTIAL_SHUFFLE
   }
 }

--- a/common/src/main/java/org/apache/nemo/common/ir/executionproperty/ExecutionPropertyMap.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/executionproperty/ExecutionPropertyMap.java
@@ -73,6 +73,7 @@ public final class ExecutionPropertyMap<T extends ExecutionProperty> implements 
     map.put(EncoderProperty.of(EncoderFactory.DUMMY_ENCODER_FACTORY));
     map.put(DecoderProperty.of(DecoderFactory.DUMMY_DECODER_FACTORY));
     switch (commPattern) {
+      case PARTIAL_SHUFFLE:
       case SHUFFLE:
         map.put(DataFlowProperty.of(DataFlowProperty.Value.PULL));
         map.put(PartitionerProperty.of(PartitionerProperty.Type.HASH));

--- a/common/src/main/java/org/apache/nemo/common/ir/vertex/executionproperty/ShuffleExecutorSetProperty.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/vertex/executionproperty/ShuffleExecutorSetProperty.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.nemo.common.ir.vertex.executionproperty;
+
+import org.apache.nemo.common.ir.executionproperty.VertexExecutionProperty;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+/**
+ * List of set of node names to limit the scheduling of the tasks of the vertex to while shuffling.
+ */
+public final class ShuffleExecutorSetProperty extends VertexExecutionProperty<ArrayList<HashSet<String>>> {
+
+  /**
+   * Default constructor.
+   * @param value value of the execution property.
+   */
+  private ShuffleExecutorSetProperty(final ArrayList<HashSet<String>> value) {
+    super(value);
+  }
+
+  /**
+   * Static method for constructing {@link ShuffleExecutorSetProperty}.
+   *
+   * @param setsOfExecutors the list of executors to schedule the tasks of the vertex on.
+   *                        Leave empty to make it effectless.
+   * @return the new execution property
+   */
+  public static ShuffleExecutorSetProperty of(final HashSet<HashSet<String>> setsOfExecutors) {
+    return new ShuffleExecutorSetProperty(new ArrayList<>(setsOfExecutors));
+  }
+}

--- a/common/src/test/java/org/apache/nemo/common/ir/IRDAGTest.java
+++ b/common/src/test/java/org/apache/nemo/common/ir/IRDAGTest.java
@@ -327,6 +327,15 @@ public class IRDAGTest {
     mustPass();
   }
 
+  @Test
+  public void testAccumulatorVertex() {
+    final OperatorVertex cv = new OperatorVertex(new EmptyComponents.EmptyTransform("iav"));
+    cv.setProperty(ShuffleExecutorSetProperty.of(new HashSet<>()));
+    cv.setProperty(ParallelismProperty.of(5));
+    irdag.insert(cv, shuffleEdge);
+    mustPass();
+  }
+
   private MessageAggregatorVertex insertNewTriggerVertex(final IRDAG dag, final IREdge edgeToGetStatisticsOf) {
     final MessageGeneratorVertex mb = new MessageGeneratorVertex<>((l, r) -> null);
     final MessageAggregatorVertex ma = new MessageAggregatorVertex<>(() -> new Object(), (l, r) -> null);

--- a/compiler/optimizer/pom.xml
+++ b/compiler/optimizer/pom.xml
@@ -73,5 +73,17 @@ under the License.
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>
+    <!-- for optimizing frontend-specific components -->
+    <dependency>
+      <groupId>org.apache.nemo</groupId>
+      <artifactId>nemo-compiler-frontend-beam</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.nemo</groupId>
+      <artifactId>nemo-compiler-frontend-beam</artifactId>
+      <version>0.4-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/compiler/optimizer/src/main/java/org/apache/nemo/compiler/optimizer/pass/compiletime/annotating/PipeTransferForAllEdgesPass.java
+++ b/compiler/optimizer/src/main/java/org/apache/nemo/compiler/optimizer/pass/compiletime/annotating/PipeTransferForAllEdgesPass.java
@@ -19,6 +19,8 @@
 package org.apache.nemo.compiler.optimizer.pass.compiletime.annotating;
 
 import org.apache.nemo.common.ir.IRDAG;
+import org.apache.nemo.common.ir.edge.executionproperty.DataFlowProperty;
+import org.apache.nemo.common.ir.edge.executionproperty.DataPersistenceProperty;
 import org.apache.nemo.common.ir.edge.executionproperty.DataStoreProperty;
 
 /**
@@ -37,9 +39,11 @@ public final class PipeTransferForAllEdgesPass extends AnnotatingPass {
   public IRDAG apply(final IRDAG dag) {
     dag.getVertices().forEach(vertex ->
       dag.getIncomingEdgesOf(vertex).stream()
-        .forEach(edge -> edge.setPropertyPermanently(
-          DataStoreProperty.of(DataStoreProperty.Value.PIPE)))
-    );
+        .forEach(edge -> {
+          edge.setPropertyPermanently(DataStoreProperty.of(DataStoreProperty.Value.PIPE));
+          edge.setPropertyPermanently(DataFlowProperty.of(DataFlowProperty.Value.PUSH));
+          edge.setPropertyPermanently(DataPersistenceProperty.of(DataPersistenceProperty.Value.DISCARD));
+        }));
     return dag;
   }
 }

--- a/compiler/optimizer/src/main/java/org/apache/nemo/compiler/optimizer/pass/compiletime/reshaping/IntermediateAccumulatorInsertionPass.java
+++ b/compiler/optimizer/src/main/java/org/apache/nemo/compiler/optimizer/pass/compiletime/reshaping/IntermediateAccumulatorInsertionPass.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nemo.compiler.optimizer.pass.compiletime.reshaping;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.nemo.common.Util;
+import org.apache.nemo.common.exception.SchedulingException;
+import org.apache.nemo.common.ir.IRDAG;
+import org.apache.nemo.common.ir.edge.IREdge;
+import org.apache.nemo.common.ir.edge.executionproperty.CommunicationPatternProperty;
+import org.apache.nemo.common.ir.vertex.OperatorVertex;
+import org.apache.nemo.common.ir.vertex.executionproperty.ParallelismProperty;
+import org.apache.nemo.common.ir.vertex.executionproperty.ShuffleExecutorSetProperty;
+import org.apache.nemo.compiler.frontend.beam.transform.CombineTransform;
+import org.apache.nemo.compiler.optimizer.pass.compiletime.Requires;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Pass for inserting intermediate aggregator for partial shuffle.
+ */
+@Requires(ParallelismProperty.class)
+public class IntermediateAccumulatorInsertionPass extends ReshapingPass {
+  private final String networkFilePath;
+  private boolean isUnitTest = false;
+  private static final Map<String, ArrayList<String>> UNIT_TEST_NETWORK_FILE = getUnitTestNetworkFile();
+
+  /**
+   * Default constructor.
+   */
+  public IntermediateAccumulatorInsertionPass() {
+    super(IntermediateAccumulatorInsertionPass.class);
+    this.networkFilePath = Util.fetchProjectRootPath() + "/bin/labeldict.json";
+  }
+
+  /**
+   * Constructor for unit test.
+   * @param isUnitTest indicates unit test.
+   */
+  public IntermediateAccumulatorInsertionPass(final boolean isUnitTest) {
+    this();
+    this.isUnitTest = isUnitTest;
+  }
+
+  private static Map<String, ArrayList<String>> getUnitTestNetworkFile() {
+    Map<String, ArrayList<String>> map = new HashMap<>();
+    map.put("0", new ArrayList<>(Arrays.asList("mulan-16.maas", "0")));
+    map.put("1", new ArrayList<>(Arrays.asList("mulan-23.maas", "0")));
+    map.put("2", new ArrayList<>(Arrays.asList("mulan-m", "0")));
+    map.put("3", new ArrayList<>(Arrays.asList("1+2", "0.00003721")));
+    map.put("4", new ArrayList<>(Arrays.asList("0+3", "2.19395143")));
+    return map;
+  }
+
+  /**
+   * Insert accumulator vertex based on network hierarchy.
+   *
+   * @param irdag irdag to apply pass.
+   * @return modified irdag.
+   */
+  @Override
+  public IRDAG apply(final IRDAG irdag) {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      Map<String, ArrayList<String>> map;
+      if (isUnitTest) {
+        map = UNIT_TEST_NETWORK_FILE;
+      } else {
+        map = mapper.readValue(new File(networkFilePath), Map.class);
+      }
+
+      irdag.topologicalDo(v -> {
+        if (v instanceof OperatorVertex && ((OperatorVertex) v).getTransform() instanceof CombineTransform) {
+          final CombineTransform finalCombineStreamTransform = (CombineTransform) ((OperatorVertex) v).getTransform();
+          if (finalCombineStreamTransform.getIntermediateCombine().isPresent()) {
+            irdag.getIncomingEdgesOf(v).forEach(e -> {
+              if (CommunicationPatternProperty.Value.SHUFFLE
+                .equals(e.getPropertyValue(CommunicationPatternProperty.class)
+                  .orElse(CommunicationPatternProperty.Value.ONE_TO_ONE))) {
+                handleDataTransferFor(irdag, map, finalCombineStreamTransform, e, 10F);
+              }
+            });
+          }
+        }
+      });
+
+      return irdag;
+    } catch (final Exception e) {
+      throw new SchedulingException(e);
+    }
+  }
+
+  private static void handleDataTransferFor(final IRDAG irdag,
+                                            final Map<String, ArrayList<String>> map,
+                                            final CombineTransform finalCombineStreamTransform,
+                                            final IREdge targetEdge,
+                                            final Float threshold) {
+    final int srcParallelism = targetEdge.getSrc().getPropertyValue(ParallelismProperty.class).get();
+
+    final int mapSize = map.size();
+    final int numOfNodes = (mapSize + 1) / 2;
+    Float previousDistance = 0F;
+
+    for (int i = numOfNodes; i < mapSize; i++) {
+      final float currentDistance = Float.parseFloat(map.get(String.valueOf(i)).get(1));
+      if (previousDistance != 0 && currentDistance > threshold * previousDistance
+        && srcParallelism * 2 / 3 >= mapSize - i + 1) {
+        final Integer targetNumberOfSets = mapSize - i;
+        final HashSet<HashSet<String>> setsOfExecutors = getTargetNumberOfExecutorSetsFrom(map, targetNumberOfSets);
+
+        final CombineTransform<?, ?, ?> intermediateCombineStreamTransform =
+          (CombineTransform) finalCombineStreamTransform.getIntermediateCombine().get();
+        final OperatorVertex accumulatorVertex = new OperatorVertex(intermediateCombineStreamTransform);
+
+        targetEdge.getDst().copyExecutionPropertiesTo(accumulatorVertex);
+        accumulatorVertex.setProperty(ParallelismProperty.of(srcParallelism * 2 / 3));
+        accumulatorVertex.setProperty(ShuffleExecutorSetProperty.of(setsOfExecutors));
+
+        irdag.insert(accumulatorVertex, targetEdge);
+        break;
+      }
+      previousDistance = currentDistance;
+    }
+  }
+
+  private static HashSet<HashSet<String>> getTargetNumberOfExecutorSetsFrom(final Map<String, ArrayList<String>> map,
+                                                                            final Integer targetNumber) {
+    final HashSet<HashSet<String>> result = new HashSet<>();
+    final Integer index = map.size() - targetNumber;
+    final List<String> indicesToCheck = IntStream.range(0, index)
+      .map(i -> -i).sorted().map(i -> -i)
+      .mapToObj(String::valueOf)
+      .collect(Collectors.toList());
+
+    Arrays.asList(map.get(String.valueOf(index)).get(0).split("\\+"))
+      .forEach(key -> result.add(recursivelyExtractExecutorsFrom(map, key, indicesToCheck)));
+
+    while (!indicesToCheck.isEmpty()) {
+      result.add(recursivelyExtractExecutorsFrom(map, indicesToCheck.get(0), indicesToCheck));
+    }
+
+    return result;
+  }
+
+  private static HashSet<String> recursivelyExtractExecutorsFrom(final Map<String, ArrayList<String>> map,
+                                                                 final String key,
+                                                                 final List<String> indicesToCheck) {
+    indicesToCheck.remove(key);
+    final HashSet<String> result = new HashSet<>();
+    final List<String> indices = Arrays.asList(map.get(key).get(0).split("\\+"));
+    if (indices.size() == 1) {
+      result.add(indices.get(0));
+    } else {
+      indices.forEach(index -> result.addAll(recursivelyExtractExecutorsFrom(map, index, indicesToCheck)));
+    }
+    return result;
+  }
+}

--- a/compiler/optimizer/src/main/java/org/apache/nemo/compiler/optimizer/pass/compiletime/reshaping/IntermediateAccumulatorInsertionPass.java
+++ b/compiler/optimizer/src/main/java/org/apache/nemo/compiler/optimizer/pass/compiletime/reshaping/IntermediateAccumulatorInsertionPass.java
@@ -49,7 +49,7 @@ public class IntermediateAccumulatorInsertionPass extends ReshapingPass {
    */
   public IntermediateAccumulatorInsertionPass() {
     super(IntermediateAccumulatorInsertionPass.class);
-    this.networkFilePath = Util.fetchProjectRootPath() + "/bin/labeldict.json";
+    this.networkFilePath = Util.fetchProjectRootPath() + "/bin/network_profiling/labeldict.json";
   }
 
   /**

--- a/compiler/optimizer/src/main/java/org/apache/nemo/compiler/optimizer/policy/IntermediateAccumulatorPolicy.java
+++ b/compiler/optimizer/src/main/java/org/apache/nemo/compiler/optimizer/policy/IntermediateAccumulatorPolicy.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.nemo.compiler.optimizer.policy;
+
+import org.apache.nemo.common.ir.IRDAG;
+import org.apache.nemo.compiler.optimizer.pass.compiletime.annotating.PipeTransferForAllEdgesPass;
+import org.apache.nemo.compiler.optimizer.pass.compiletime.composite.DefaultCompositePass;
+import org.apache.nemo.compiler.optimizer.pass.compiletime.reshaping.IntermediateAccumulatorInsertionPass;
+import org.apache.nemo.compiler.optimizer.pass.runtime.Message;
+
+/**
+ * A policy to perform intermediate data accumulation in shuffle edges (e.g. WAN networks).
+ */
+public final class IntermediateAccumulatorPolicy implements Policy {
+  public static final PolicyBuilder BUILDER =
+    new PolicyBuilder()
+      .registerCompileTimePass(new DefaultCompositePass())
+      .registerCompileTimePass(new PipeTransferForAllEdgesPass())
+      .registerCompileTimePass(new IntermediateAccumulatorInsertionPass());
+
+  private final Policy policy;
+
+  /**
+   * Default constructor.
+   */
+  public IntermediateAccumulatorPolicy() {
+    this.policy = BUILDER.build();
+  }
+
+  @Override
+  public IRDAG runCompileTimeOptimization(final IRDAG dag, final String dagDirectory) {
+    return this.policy.runCompileTimeOptimization(dag, dagDirectory);
+  }
+
+  @Override
+  public IRDAG runRunTimeOptimizations(final IRDAG dag, final Message<?> message) {
+    return this.policy.runRunTimeOptimizations(dag, message);
+  }
+}

--- a/compiler/optimizer/src/test/java/org/apache/nemo/compiler/optimizer/policy/PolicyBuilderTest.java
+++ b/compiler/optimizer/src/test/java/org/apache/nemo/compiler/optimizer/policy/PolicyBuilderTest.java
@@ -46,6 +46,12 @@ public final class PolicyBuilderTest {
   }
 
   @Test
+  public void testIntermediateAccumulatorPolicy() {
+    assertEquals(11, IntermediateAccumulatorPolicy.BUILDER.getCompileTimePasses().size());
+    assertEquals(0, IntermediateAccumulatorPolicy.BUILDER.getRunTimePasses().size());
+  }
+
+  @Test
   public void testShouldFailPolicy() {
     try {
       final Policy failPolicy = new PolicyBuilder()

--- a/compiler/test/src/main/java/org/apache/nemo/compiler/CompilerTestUtil.java
+++ b/compiler/test/src/main/java/org/apache/nemo/compiler/CompilerTestUtil.java
@@ -143,4 +143,25 @@ public final class CompilerTestUtil {
       .addUserArgs(input, numFeatures, numClasses, numIteration);
     return compileDAG(mlrArgBuilder.build());
   }
+
+  public static IRDAG compileEDGARDAG() throws Exception {
+    final String input = ROOT_DIR + "/examples/resources/inputs/test_input_windowed_wordcount";
+    final String windowType = "fixed";
+    final String inputType = "bounded";
+    final String main = "org.apache.nemo.examples.beam.WindowedWordCount";
+    final String output = ROOT_DIR + "/examples/resources/inputs/test_output";
+    final String scheduler = "org.apache.nemo.runtime.master.scheduler.StreamingScheduler";
+    final String resourceJson = ROOT_DIR + "/examples/resources/executors/beam_test_executor_resources.json";
+    final String jobId = "testIntermediateAccumulatorInsertionPass";
+    final String policy = "org.apache.nemo.compiler.optimizer.policy.StreamingPolicy";
+
+    final ArgBuilder edgarArgBuilder = new ArgBuilder()
+      .addScheduler(scheduler)
+      .addUserMain(main)
+      .addUserArgs(output, windowType, inputType, input)
+      .addResourceJson(resourceJson)
+      .addJobId(jobId)
+      .addOptimizationPolicy(policy);
+    return compileDAG(edgarArgBuilder.build());
+  }
 }

--- a/compiler/test/src/test/java/org/apache/nemo/compiler/optimizer/pass/compiletime/reshaping/IntermediateAccumulatorInsertionPassTest.java
+++ b/compiler/test/src/test/java/org/apache/nemo/compiler/optimizer/pass/compiletime/reshaping/IntermediateAccumulatorInsertionPassTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nemo.compiler.optimizer.pass.compiletime.reshaping;
+
+import org.apache.nemo.client.JobLauncher;
+import org.apache.nemo.common.ir.IRDAG;
+import org.apache.nemo.common.ir.vertex.executionproperty.ShuffleExecutorSetProperty;
+import org.apache.nemo.compiler.CompilerTestUtil;
+import org.apache.nemo.compiler.optimizer.pass.compiletime.annotating.*;
+import org.apache.nemo.compiler.optimizer.policy.Policy;
+import org.apache.nemo.compiler.optimizer.policy.PolicyBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.nemo.common.dag.DAG.EMPTY_DAG_DIRECTORY;
+
+/**
+ * Test {@link IntermediateAccumulatorInsertionPass}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(JobLauncher.class)
+public class IntermediateAccumulatorInsertionPassTest {
+  private IRDAG compiledDAG;
+
+  @Before
+  public void setUp() throws Exception {
+    compiledDAG = CompilerTestUtil.compileEDGARDAG();
+  }
+
+  @Test
+  public void testIntermediateAccumulatorInsertionPass() {
+    final PolicyBuilder builder = new PolicyBuilder();
+    builder.registerCompileTimePass(new DefaultParallelismPass(16, 2))
+      .registerCompileTimePass(new DefaultEdgeEncoderPass())
+      .registerCompileTimePass(new DefaultEdgeDecoderPass())
+      .registerCompileTimePass(new DefaultDataStorePass())
+      .registerCompileTimePass(new DefaultDataPersistencePass())
+      .registerCompileTimePass(new DefaultScheduleGroupPass())
+      .registerCompileTimePass(new CompressionPass())
+      .registerCompileTimePass(new ResourceLocalityPass())
+      .registerCompileTimePass(new ResourceSlotPass())
+      .registerCompileTimePass(new PipeTransferForAllEdgesPass())
+      .registerCompileTimePass(new IntermediateAccumulatorInsertionPass(true));
+    final Policy policy = builder.build();
+    compiledDAG = policy.runCompileTimeOptimization(compiledDAG, EMPTY_DAG_DIRECTORY);
+    assertTrue(compiledDAG.getTopologicalSort().stream()
+      .anyMatch(v -> v.getPropertyValue(ShuffleExecutorSetProperty.class).isPresent()));
+    assertTrue(compiledDAG.checkIntegrity().isPassed());
+  }
+}

--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/datatransfer/PipeInputReader.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/datatransfer/PipeInputReader.java
@@ -71,7 +71,8 @@ public final class PipeInputReader implements InputReader {
     if (comValue.equals(CommunicationPatternProperty.Value.ONE_TO_ONE)) {
       return Collections.singletonList(pipeManagerWorker.read(dstTaskIndex, runtimeEdge, dstTaskIndex));
     } else if (comValue.equals(CommunicationPatternProperty.Value.BROADCAST)
-      || comValue.equals(CommunicationPatternProperty.Value.SHUFFLE)) {
+      || comValue.equals(CommunicationPatternProperty.Value.SHUFFLE)
+      || comValue.equals(CommunicationPatternProperty.Value.PARTIAL_SHUFFLE)) {
       final int numSrcTasks = InputReader.getSourceParallelism(this);
       final List<CompletableFuture<DataUtil.IteratorWithNumBytes>> futures = new ArrayList<>();
       for (int srcTaskIdx = 0; srcTaskIdx < numSrcTasks; srcTaskIdx++) {


### PR DESCRIPTION
JIRA: [NEMO-472: Fix and Implement Hierarchical Aggregation](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-472)

**Major changes:**
- Added new type of communication channel(Partial Shuffle)
- Implemented pass that inserts accumulator vertex, which performs hierarchical aggregation during shuffle.
- Implemented unit tests

**Minor changes to note:**
- None

**Tests for the changes:**
- Tested on my Mac and ubuntu machine

**Other comments:**
- Network hierarchy information is in bin/network_profiling/labeldict.json
(See PR#315)
- Currently, data transfer on partial shuffle communication channel is exactly same with shuffle. It must be implemented.
- Need more conditions when applying pass.